### PR TITLE
BUGFIX: Make compatible to PHP 7.3

### DIFF
--- a/Classes/Service/SiteDeterminationService.php
+++ b/Classes/Service/SiteDeterminationService.php
@@ -12,7 +12,7 @@ use GuzzleHttp\Psr7\ServerRequest;
 
 class SiteDeterminationService
 {
-    public static ?string $siteName = null;
+    public static $siteName = null;
 
     public function getCurrentSiteName(): ?string
     {

--- a/Classes/Service/SiteSpecificContentDimensionPresetSource.php
+++ b/Classes/Service/SiteSpecificContentDimensionPresetSource.php
@@ -29,7 +29,7 @@ class SiteSpecificContentDimensionPresetSource extends ConfigurationContentDimen
      */
     protected $settings;
 
-    protected bool $configurationAdjusted = false;
+    protected $configurationAdjusted = false;
 
     public function initializeObject(): void
     {


### PR DESCRIPTION
The package claims compatibility with Neos 5, which in in turn
needs Flow 6, which supports PHP 7.3 and up.

Typed properties are a PHP 7.4 feature, and must thus not be used.